### PR TITLE
taggedunion: Use tagattrname in internally tagged json marshal

### DIFF
--- a/pkg/wdl/macro/go_taggedunion_internally.go
+++ b/pkg/wdl/macro/go_taggedunion_internally.go
@@ -41,7 +41,7 @@ func (m *GoTaggedUnion) goTaggedUnionJSONInternallyTagged(opts goTaggedUnionPara
 						strCaseConst = wdl.Identifier(opts.Names[idx])
 					}
 					tmp += fmt.Sprintf("case %d:\n", ord)
-					tmp += fmt.Sprintf("prefix = []byte(`{\"type\":%s`)\n", strconv.Quote(strCaseConst.String()))
+					tmp += fmt.Sprintf("prefix = []byte(`{\"%s\":%s`)\n", tagAttrName, strconv.Quote(strCaseConst.String()))
 				}
 				tmp += "}\n"
 				blk.Add(wdl.RawStmt(tmp))


### PR DESCRIPTION
This commit fixes the support for changing the tag attribute name on internally tagged enums.

Previously, given the following enum declaration:

```go
type (
	Foo struct{ A int }
	Bar struct{ B int }
)

// #[go.TaggedUnion "json":"internal", "tag":"AAAAAAA", "names":[]]
type _Something interface{ Foo | Bar }
```

We produced the following json:
```
{"type":"Bar","B":0}
```

In `goTaggedUnionJSONInternallyTagged` we hard-coded the tag attr name to `type`, so lets use the `tagAttrName` param instead.

We now produce the following, correct, json:

```
{"AAAAAAA":"Bar","B":0}
```

The `UnMarshal` side of things already works correctly.